### PR TITLE
Update configs and add kill script

### DIFF
--- a/config/nssfcfg.conf
+++ b/config/nssfcfg.conf
@@ -73,6 +73,12 @@ configuration:
       nsiInformationList:
         - nrfId: http://localhost:29510/nnrf-nfm/v1/nf-instances
           nsiId: 22
+    - snssai:
+        sst: 1
+        sd: 112233
+      nsiInformationList:
+        - nrfId: http://localhost:29510/nnrf-nfm/v1/nf-instances
+          nsiId: 23
   amfSetList:
     - amfSetId: 1
       amfList:

--- a/config/smfcfg.conf
+++ b/config/smfcfg.conf
@@ -1,6 +1,6 @@
 info:
   version: 1.0.0
-  description:  initial local configuration
+  description: SMF initial local configuration
 
 configuration:
   smfName: SMF
@@ -35,11 +35,14 @@ configuration:
         an_ip: 127.0.0.100
       UPF:
         type: UPF
-        node_id:  127.0.0.8
-        up_resource_ip: 192.188.2.2
-      
+        node_id:  10.200.200.101
     links:
       - A: gNB1
         B: UPF
   ue_subnet: 60.60.0.0/16
+  dnn:
+    internet:
+      dns:
+        ipv4: 8.8.8.8
+        ipv6: 2001:4860:4860::8888
   nrfUri: http://localhost:29510

--- a/config/test/smfcfg.single.test.conf
+++ b/config/test/smfcfg.single.test.conf
@@ -1,6 +1,6 @@
 info:
   version: 1.0.0
-  description: AMF initial local configuration
+  description: SMF initial local configuration
 
 configuration:
   smfName: SMF
@@ -36,7 +36,6 @@ configuration:
       UPF:
         type: UPF
         node_id: 10.200.200.101
-        up_resource_ip: 192.188.2.2
     links:
       - A: gNB1
         B: UPF

--- a/force_kill.sh
+++ b/force_kill.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+NF_LIST="nrf amf smf udr pcf udm nssf ausf n3iwf free5gc-upfd"
+
+for NF in ${NF_LIST}; do
+    sudo killall -9 ${NF}
+done
+
+sudo ip link del upfgtp0
+

--- a/sample/ran_attach_config/nssfcfg.conf
+++ b/sample/ran_attach_config/nssfcfg.conf
@@ -73,6 +73,12 @@ configuration:
       nsiInformationList:
         - nrfId: http://localhost:29510/nnrf-nfm/v1/nf-instances
           nsiId: 22
+    - snssai:
+        sst: 1
+        sd: 112233
+      nsiInformationList:
+        - nrfId: http://localhost:29510/nnrf-nfm/v1/nf-instances
+          nsiId: 23
   amfSetList:
     - amfSetId: 1
       amfList:


### PR DESCRIPTION
Hi,

I made two small updates in this PR:
- Update sample configs to make network slices info consistent across NFs.
- Add script `force_kill.sh` to quickly kill all NFs and remove the default gtp virtual interface.