### PR TITLE
Fixed run.sh.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -19,11 +19,8 @@ for NF in ${NF_LIST}; do
     PID_LIST+=($!)
 done
 
-sudo ./bin/n3iwf &
-SUDO_N3IWF_PID=$!
-sleep 1
-N3IWF_PID=`pgrep -P $SUDO_N3IWF_PID`
-PID_LIST+=($SUDO_N3IWF_PID $N3IWF_PID)
+./bin/n3iwf &
+PID_LIST+=($!)
 
 function terminate()
 {

--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,7 @@ for NF in ${NF_LIST}; do
     PID_LIST+=($!)
 done
 
-sudo ./bin/n3iwf &
+./bin/n3iwf &
 PID_LIST+=($!)
 
 function terminate()

--- a/run.sh
+++ b/run.sh
@@ -19,8 +19,11 @@ for NF in ${NF_LIST}; do
     PID_LIST+=($!)
 done
 
-./bin/n3iwf &
-PID_LIST+=($!)
+sudo ./bin/n3iwf &
+SUDO_N3IWF_PID=$!
+sleep 1
+N3IWF_PID=`pgrep -P $SUDO_N3IWF_PID`
+PID_LIST+=($SUDO_N3IWF_PID $N3IWF_PID)
 
 function terminate()
 {


### PR DESCRIPTION
A tiny change to kill the n3iwf process at terminating run.sh.

I'm running run.sh as root. At the terminating,
```
sudo ./bin/n3iwf
```
The above process ID was killed, but the following process ID was not killed.
```
./bin/n3iwf
```
If n3iwf requires sudo, I would like to use another suitable PR.