### PR TITLE
Update AMF and SMF config for UPF selection according to connected gNB

### DIFF
--- a/config/amfcfg.n3test.yaml
+++ b/config/amfcfg.n3test.yaml
@@ -50,6 +50,7 @@ configuration:
   networkName:  # the name of this core network
     full: free5GC
     short: free
+  locality: area1 # Name of the location where a set of AMF, SMF and UPFs are located
   networkFeatureSupport5GS: # 5gs Network Feature Support IE, refer to TS 24.501
     enable: true # append this IE in Registration accept or not
     imsVoPS: 0 # IMS voice over PS session indicator (uinteger, range: 0~1)

--- a/config/amfcfg.yaml
+++ b/config/amfcfg.yaml
@@ -50,6 +50,7 @@ configuration:
   networkName:  # the name of this core network
     full: free5GC
     short: free
+  locality: area1 # Name of the location where a set of AMF, SMF and UPFs are located
   networkFeatureSupport5GS: # 5gs Network Feature Support IE, refer to TS 24.501
     enable: true # append this IE in Registration accept or not
     imsVoPS: 0 # IMS voice over PS session indicator (uinteger, range: 0~1)

--- a/config/multiUPF/smfcfg.ulcl.yaml
+++ b/config/multiUPF/smfcfg.ulcl.yaml
@@ -160,6 +160,7 @@ configuration:
       - A: gNB1
         B: UPF6
   nrfUri: http://127.0.0.10:8000
+  locality: area1
   ulcl: true
 
 logger:

--- a/config/smfcfg.yaml
+++ b/config/smfcfg.yaml
@@ -64,6 +64,7 @@ configuration:
       - A: gNB1
         B: UPF
   nrfUri: http://127.0.0.10:8000 # a valid URI of NRF
+  locality: area1 # Name of the location where a set of AMF, SMF and UPFs are located
 
 # the kind of log output
   # debugLevel: how detailed to output, value: trace, debug, info, warn, error, fatal, panic

--- a/config/test/smfcfg.pdusessions.test.yaml
+++ b/config/test/smfcfg.pdusessions.test.yaml
@@ -87,6 +87,7 @@ configuration:
         B: AnchorUPF2
   ue_subnet: 60.60.0.0/16
   nrfUri: http://127.0.0.10:8000
+  locality: area1
   ulcl: false
 
 logger:

--- a/config/test/smfcfg.single.test.yaml
+++ b/config/test/smfcfg.single.test.yaml
@@ -67,6 +67,7 @@ configuration:
       - A: gNB1
         B: UPF
   nrfUri: http://127.0.0.10:8000
+  locality: area1
 
 logger:
   SMF:

--- a/config/test/smfcfg.ulcl.test.yaml
+++ b/config/test/smfcfg.ulcl.test.yaml
@@ -114,6 +114,7 @@ configuration:
       - A: BranchingUPF
         B: AnchorUPF2
   nrfUri: http://127.0.0.10:8000
+  locality: area1
   ulcl: true
 
 logger:


### PR DESCRIPTION
This PR adds locality in amfcfg.yaml and smfcfg.yaml. Please see free5gc/amf#37 and free5gc/smf#25 for the actual changes made.