### PR TITLE
fix webconsole no logger block

### DIFF
--- a/config/webuicfg.yaml
+++ b/config/webuicfg.yaml
@@ -3,6 +3,23 @@ info:
   description: WebUI initial local configuration
 
 configuration:
-  mongodb: # the mongodb connected by this webui
-    name: free5gc # name of the mongodb
-    url: mongodb://localhost:27017 # a valid URL of the mongodb
+  mongodb:                          # the mongodb connected by this webui
+    name: free5gc                   # name of the mongodb
+    url: mongodb://localhost:27017  # a valid URL of the mongodb
+
+# the kind of log output
+# debugLevel: how detailed to output, value: trace, debug, info, warn, error, fatal, panic
+# ReportCaller: enable the caller report or not, value: true or false
+logger:
+  WEBUI:
+    debugLevel: info
+    ReportCaller: true
+  PathUtil:
+    debugLevel: info
+    ReportCaller: false
+  OpenApi:
+    debugLevel: info
+    ReportCaller: false
+  MongoDBLibrary:
+    debugLevel: info
+    ReportCaller: false


### PR DESCRIPTION
Fix the webconsole config no logger block
Add the logger ```WEBIO```、```PathUtils```、```OpenApi```、``` MongoDBLibrary```

- Oringin Config Startup

```
[WARN][WebUI][Init] Webconsole config without log level setting!!!
```

- Fixed Config Startup
```
[INFO][WebUI][Init] WebUI Log level is set to [info] level
[INFO][LIB][Path] set log level : info
[INFO][LIB][Path] set report call : false
[INFO][LIB][OAPI] set log level : info
[INFO][LIB][OAPI] set report call : false
[INFO][LIB][MonDB] set log level : info
[INFO][LIB][MonDB] set report call : false
```

Refer to: [free5gc/webconsole](https://github.com/free5gc/webconsole/blob/7da0c48c67244c9b57d138ef3472dac38d76e7f4/backend/webui_service/webui_init.go#L81) check logger block

Signed-off-by: zhengsheng0524 <j13tw@yahoo.com.tw>