### PR TITLE
support retransmission of identity request

### DIFF
--- a/config/amfcfg.yaml
+++ b/config/amfcfg.yaml
@@ -88,6 +88,11 @@ configuration:
     enable: true     # true or false
     expireTime: 6s   # default is 6 seconds
     maxRetryTimes: 4 # the max number of retransmission
+  # retransmission timer for NAS Identity Request message
+  t3570:
+    enable: true     # true or false
+    expireTime: 6s   # default is 6 seconds
+    maxRetryTimes: 4 # the max number of retransmission
 
 # the kind of log output
   # debugLevel: how detailed to output, value: trace, debug, info, warn, error, fatal, panic


### PR DESCRIPTION
Add T3570 in amfcfg.yaml for retransmission of identity request.
Please see free5gc/amf#50 for the modification of amf.