### PR TITLE
Enable static linking for the webconsole

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ $(WEBCONSOLE)/$(GO_BIN_PATH)/$(WEBCONSOLE): $(WEBCONSOLE)/server.go  $(WEBCONSOL
 	rm -rf ../public && \
 	cp -R build ../public
 	cd $(WEBCONSOLE) && \
-	go build -ldflags "$(WEBCONSOLE_LDFLAGS)" -o $(ROOT_PATH)/$@ ./server.go
+	CGO_ENABLED=0 go build -ldflags "$(WEBCONSOLE_LDFLAGS)" -o $(ROOT_PATH)/$@ ./server.go
 
 clean:
 	rm -rf $(addprefix $(GO_BIN_PATH)/, $(GO_NF))


### PR DESCRIPTION
All pure Go NFs are build with CGO_ENABLED=0. Since the webconsole is compiled separately, I think the flag was missed. Without it the webconsole binary would be dynamically linked.
Building a statically linked binary allows running the webconsole in an alpine based container.

Cheers,