### PR TITLE
Makefile: Add js files to dependencies for webconsole target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ WEBCONSOLE = webconsole
 
 NF_GO_FILES = $(shell find $(GO_SRC_PATH)/$(%) -name "*.go" ! -name "*_test.go")
 WEBCONSOLE_GO_FILES = $(shell find $(WEBCONSOLE) -name "*.go" ! -name "*_test.go")
+WEBCONSOLE_JS_FILES = $(shell find $(WEBCONSOLE)/frontend -name '*.js' ! -path "*/node_modules/*")
 
 VERSION = $(shell git describe --tags)
 BUILD_TIME = $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -59,7 +60,7 @@ $(C_NF): % :
 
 $(WEBCONSOLE): $(WEBCONSOLE)/$(GO_BIN_PATH)/$(WEBCONSOLE)
 
-$(WEBCONSOLE)/$(GO_BIN_PATH)/$(WEBCONSOLE): $(WEBCONSOLE)/server.go  $(WEBCONSOLE_GO_FILES)
+$(WEBCONSOLE)/$(GO_BIN_PATH)/$(WEBCONSOLE): $(WEBCONSOLE)/server.go $(WEBCONSOLE_GO_FILES) $(WEBCONSOLE_JS_FILES)
 	@echo "Start building $(@F)...."
 	cd $(WEBCONSOLE)/frontend && \
 	yarn install && \


### PR DESCRIPTION
I noticed that the webconsole is only re-built when golang files change. It would also make sense to re-build the webconsole when JavaScript files change, so that frontend changes also trigger a new build.

I have been working with this adapted Makefile for some time now and it works as expected, so I wanted to share it with you.

This PR somewhat relates to my [refactoring activities in the webconsole](https://github.com/free5gc/webconsole/pull/43).