### PR TITLE
Fix: Pass testcase TestNon3GPP

### DIFF
--- a/test/consumerTestdata/PCF/TestAMPolicy/AMPolicy.go
+++ b/test/consumerTestdata/PCF/TestAMPolicy/AMPolicy.go
@@ -66,7 +66,7 @@ func GetAMreqdata() models.PolicyAssociationRequest {
 					Tacs: []string{
 						"000001",
 					},
-					AreaCodes: "+886",
+					AreaCode: "+886",
 				},
 			},
 			MaxNumOfTAs: 999,
@@ -142,7 +142,7 @@ func GetAMUpdateReqData() models.PolicyAssociationUpdateRequest {
 					Tacs: []string{
 						"000002",
 					},
-					AreaCodes: "+886",
+					AreaCode: "+886",
 				},
 			},
 			MaxNumOfTAs: 123,

--- a/test/non3gpp_test.go
+++ b/test/non3gpp_test.go
@@ -1718,6 +1718,12 @@ func TestNon3GPPUE(t *testing.T) {
 		t.Fatalf("Applying XFRM rules failed: %+v", err)
 	}
 
+	// TODO
+	// We don't check any of message in UeConfigUpdate Message
+	if _, err := tcpConnWithN3IWF.Read(buffer); err != nil {
+		t.Fatalf("No UeConfigUpdate Message: %+v", err)
+	}
+
 	var pduAddress net.IP
 
 	// Read NAS from N3IWF

--- a/test/non3gpp_test.go
+++ b/test/non3gpp_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/free5gc/nas/nasMessage"
 	"github.com/free5gc/nas/nasType"
 	"github.com/free5gc/nas/security"
+	"github.com/free5gc/ngap"
 	"github.com/free5gc/openapi/models"
 	"github.com/free5gc/util/ueauth"
 )
@@ -1720,8 +1721,12 @@ func TestNon3GPPUE(t *testing.T) {
 
 	// TODO
 	// We don't check any of message in UeConfigUpdate Message
-	if _, err := tcpConnWithN3IWF.Read(buffer); err != nil {
+	if n, err := tcpConnWithN3IWF.Read(buffer); err != nil {
 		t.Fatalf("No UeConfigUpdate Message: %+v", err)
+		_, err := ngap.Decoder(buffer[2:n])
+		if err != nil {
+			t.Fatalf("UeConfigUpdate Decode Error: %+v", err)
+		}
 	}
 
 	var pduAddress net.IP


### PR DESCRIPTION
## Description 

After AMF add the cfg/cmd (https://github.com/free5gc/amf/pull/105), the testcase **TestNon3GPP** would failed. 

This pull request let **TestNon3GPP** test script skip ```UeConfigUpdate``` message and continue the following check.

## Note
The **TestNon3GPP** testcase is not in CI test. 