### PR TITLE
Update config reload script with better on screen messages

### DIFF
--- a/reload_host_config.sh
+++ b/reload_host_config.sh
@@ -3,7 +3,11 @@
 if [ -z "$1" ]
 then
     echo "[ERRO] No parameter was given!"
-    echo "[INFO] You must provide dn interface name as a parameter"
+    echo "[INFO] You must provide dn interface name as input parameter"
+    echo "Usage:"
+    echo "$0 <dn_interface>"
+    echo "Example:"
+    echo "$0 enp0s4"
 else
     echo "[INFO] Using $1 as interface name"
 
@@ -14,7 +18,7 @@ else
     echo -n "[INFO] Setting kernel net.ipv4.ip_forward flag... "
     sudo sysctl -w net.ipv4.ip_forward=1 >/dev/null
     echo "[OK]"
-    echo "[INFO] Disabling ufw firewall... "
+    echo -n "[INFO] Stopping ufw firewall... "
     sudo systemctl stop ufw
     echo "[OK]"
 


### PR DESCRIPTION
Hello,

I've updated the reload config script to give an usage example in case the parameter is missing. I've fixed the last `echo` message line break and updated it's message to reflect the actual behavior (the service is stopped, not disabled as stated by the message earlier).

Thanks.