### PR TITLE
Update webconsole build corepack command on Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ $(WEBCONSOLE): $(WEBCONSOLE)/$(GO_BIN_PATH)/$(WEBCONSOLE)
 $(WEBCONSOLE)/$(GO_BIN_PATH)/$(WEBCONSOLE): $(WEBCONSOLE)/server.go $(WEBCONSOLE_GO_FILES) $(WEBCONSOLE_JS_FILES)
 	@echo "Start building $(@F)...."
 	cd $(WEBCONSOLE)/frontend && \
-	corepack enable && \
+	sudo corepack enable && \
 	yarn install && \
 	yarn build && \
 	rm -rf ../public && \


### PR DESCRIPTION
According to the  discussions contained on this PR https://github.com/free5gc/webconsole/pull/71 on webconsole repository, corepack requires permission to correctly setup its files on the system (see comment https://github.com/free5gc/webconsole/pull/71#issuecomment-1966601037 for more details)

Then, this PR makes this small adjustment on free5GC's Makefile too