### PR TITLE
Update reload_host_config script with iptables rule drop and root credentials caching

### DIFF
--- a/reload_host_config.sh
+++ b/reload_host_config.sh
@@ -11,8 +11,17 @@ then
     echo "$0 <dn_interface>"
     echo "Example:"
     echo "$0 enp0s4"
+# then check if more than two parameters were input
+elif [ $# -gt 2 ]
+then
+    echo "[ERRO] Too many parameters!"
+    echo "Usage:"
+    echo "$0 <dn_interface> [-reset-firewall]"
+    echo "Examples:"
+    echo "$0 enp0s4"
+    echo "$0 enp0s4 -reset-firewall"
 else
-    # if any parameter is present, cache root credentials
+    # if any two parameters are present, cache root credentials
     sudo -v
     if [ $? == 1 ]
     then

--- a/reload_host_config.sh
+++ b/reload_host_config.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# checks if no parameter was given as input
 if [ -z "$1" ]
 then
     echo "[ERRO] No parameter was given!"
@@ -9,8 +10,28 @@ then
     echo "Example:"
     echo "$0 enp0s4"
 else
+    # if the parameter is present, cache root credentials
+    sudo -v
+    if [ $? == 1 ]
+    then
+        echo "[ERRO] Without root permission, you cannot change iptables configuration"
+        exit 1
+    fi
+    # if user has root permissions, then start to modify the rules
     echo "[INFO] Using $1 as interface name"
 
+    # first, delete any previous applied rules
+    echo -n "[INFO] Removing all old iptables rules, if any... "
+    sudo iptables -P INPUT ACCEPT
+    sudo iptables -P FORWARD ACCEPT
+    sudo iptables -P OUTPUT ACCEPT
+    sudo iptables -t nat -F
+    sudo iptables -t mangle -F
+    sudo iptables -F
+    sudo iptables -X
+    echo "[OK]"
+
+    # then apply the new ones
     echo -n "[INFO] Applying iptables rules... "
     sudo iptables -t nat -A POSTROUTING -o $1 -j MASQUERADE
     sudo iptables -I FORWARD 1 -j ACCEPT


### PR DESCRIPTION
This PR has these actions:

Add some commands to drop all previously applied iptables rules (it helps if running in an already setup OS or if the script is run more than once) (for more information, see [this doc page](https://free5gc.org/guide/Trouble_Shooting/#10-to-clear-all-iptables-rules))

Add a root credential cache command (to avoid asking for the password in the middle of the workflow)

Add some inline comments to improve code readability and hopefully reduce future maintenance efforts

TIA