### PR TITLE
Cache root credentials before actually running the run.sh script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -9,6 +9,13 @@ N3IWF_ENABLE=0
 PID_LIST=()
 echo $$ > run.pid
 
+sudo -v # cache credentials
+if [ $? == 1 ] # check if credentials were successfully cached
+then
+    echo "[ERRO] Without root permission, you cannot run free5GC"
+    exit 1
+fi
+
 if [ $# -ne 0 ]; then
     while [ $# -gt 0 ]; do
         case $1 in


### PR DESCRIPTION
Hello,

This PR will add a sudo credential cache to the beginning of the run.sh script so it will only be able to run if the user has super user permissions. This will make run.sh behavior consistent with the one displayed by the [test.sh script](https://github.com/free5gc/free5gc/blob/main/test.sh#L17) for example.

Thanks.