### PR TITLE
Added test option All to run all tests and print out cleaner results

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -29,10 +29,34 @@ do
 done
 shift $(($OPTIND - 1))
 
-TEST_POOL="TestRegistration|TestGUTIRegistration|TestServiceRequest|TestXnHandover|TestN2Handover|TestDeregistration|TestPDUSessionReleaseRequest|TestPaging|TestNon3GPP|TestReSynchronization|TestDuplicateRegistration|TestEAPAKAPrimeAuthentication|TestMultiAmfRegistration|TestNasReroute"
+TEST_POOL="All|TestRegistration|TestGUTIRegistration|TestServiceRequest|TestXnHandover|TestN2Handover|TestDeregistration|TestPDUSessionReleaseRequest|TestPaging|TestNon3GPP|TestReSynchronization|TestDuplicateRegistration|TestEAPAKAPrimeAuthentication|TestMultiAmfRegistration|TestNasReroute"
 if [[ ! "$1" =~ $TEST_POOL ]]
 then
     echo "Usage: $0 [ ${TEST_POOL//|/ | } ]"
+    exit 1
+fi
+
+if [ $1 == "All" ]; then
+    echo "Running All Tests"
+    echo
+    mkdir -p testing_output
+    IFS='|' read -ra ADDR <<< "$TEST_POOL"
+        for i in "${ADDR[@]}"; do
+            if [ $i == "All" ]; then
+                continue
+            fi
+            echo "$i"
+            echo "    Output saved to testing_output/$i.log"
+            exec $(realpath $0) $i &> testing_output/$i.log &
+            wait
+            STATUS=$(grep -E "\-\-\-.*:" testing_output/$i.log)
+            if [ ! -z "$STATUS" ]; then
+                echo "$STATUS" | while read -r a; do echo "    ${a:4}"; done
+            else
+                echo "    Failed"
+            fi
+            echo
+        done
     exit 1
 fi
 


### PR DESCRIPTION
I wanted to test the installation against all of the test cases in **test.sh** but there was not an option for that. I created an option ```All``` that will call the test script with every test option. The test results are then saved to a created directory **testing_output/** by the name of **<test_name>.log**. The test will also grep the files after each test has finished to neatly tell the user if the test has passed or failed.
![Screenshot from 2024-06-18 19-43-32](https://github.com/free5gc/free5gc/assets/77745791/ec0651d4-8265-4ecb-8b4a-a6cb047cfab9)
