### PR TITLE
Fix: typo in `config/smfcfg.yaml`

### DIFF
--- a/config/smfcfg.yaml
+++ b/config/smfcfg.yaml
@@ -43,7 +43,7 @@ configuration:
     listenAddr: 127.0.0.1 # the IP/FQDN of N4 interface on this SMF (PFCP)
     externalAddr: 127.0.0.1 # the IP/FQDN of N4 interface on this SMF (PFCP)
     assocFailAlertInterval: 10s
-    AssocFailRetryInterval: 30s
+    assocFailRetryInterval: 30s
     heartbeatInterval: 10s
   userplaneInformation: # list of userplane information
     upNodes: # information of userplane node (AN or UPF)


### PR DESCRIPTION
Commit 65d3f367540dc3f3362a0884b9145e3ffaf82029 introduce a typo in `config/smfcfg.yaml`.
Cf. https://github.com/free5gc/smf/blob/ed09202fd1615cfae758faf245e7ece9709a0170/pkg/factory/config.go#L257