### PR TITLE
Unify the shebang

### DIFF
--- a/force_kill.sh
+++ b/force_kill.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DROP_ALL_DB=0
 DB_NAME="free5gc"

--- a/make_gtp5gtunnel.sh
+++ b/make_gtp5gtunnel.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 SCRIPT_DIR="$(cd "$( dirname "$0" )" && pwd -P)"
 CMD_FILE="gtp5g-tunnel"
 


### PR DESCRIPTION
Hello,

Not all the shebang was unified, some of them was `#!/bin/bash` rather than `#!/usr/bin/env bash` (Some OS like NixOS aren't FHS compliant, it's why we can't directly use `/bin/bash`)

So this MR fix this detail