### PR TITLE
Update TNGF test to include the IKEv2 null encryption algorithm

### DIFF
--- a/test/tngf_test.go
+++ b/test/tngf_test.go
@@ -149,7 +149,7 @@ func tngfGenerateKeyForIKESA(ikeSecurityAssociation *context.IKESecurityAssociat
 	length_SK_d = 20
 	length_SK_ai = 20
 	length_SK_ar = length_SK_ai
-	length_SK_ei = 32
+	length_SK_ei = 0
 	length_SK_er = length_SK_ei
 	length_SK_pi, length_SK_pr = length_SK_d, length_SK_d
 	totalKeyLength = length_SK_d + length_SK_ai + length_SK_ar + length_SK_ei + length_SK_er + length_SK_pi + length_SK_pr
@@ -1253,11 +1253,9 @@ func TestTngfUE(t *testing.T) {
 	// Security Association
 	securityAssociation := ikeMessage.Payloads.BuildSecurityAssociation()
 	// Proposal 1
-	proposal := securityAssociation.Proposals.BuildProposal(1, message.TypeESP, nil)
+	proposal := securityAssociation.Proposals.BuildProposal(1, message.TypeIKE, nil)
 	// ENCR
-	var attributeType uint16 = message.AttributeTypeKeyLength
-	var keyLength uint16 = 256
-	proposal.EncryptionAlgorithm.BuildTransform(message.TypeEncryptionAlgorithm, message.ENCR_AES_CBC, &attributeType, &keyLength, nil)
+	proposal.EncryptionAlgorithm.BuildTransform(message.TypeEncryptionAlgorithm, message.ENCR_NULL, nil, nil, nil)
 	// INTEG
 	proposal.IntegrityAlgorithm.BuildTransform(message.TypeIntegrityAlgorithm, message.AUTH_HMAC_SHA1_96, nil, nil, nil)
 	// PRF
@@ -1367,7 +1365,7 @@ func TestTngfUE(t *testing.T) {
 	inboundSPI := tngfGenerateSPI(tngfue)
 	proposal = securityAssociation.Proposals.BuildProposal(1, message.TypeESP, inboundSPI)
 	// ENCR (use null encryption for ESP)
-	proposal.EncryptionAlgorithm.BuildTransform(message.TypeEncryptionAlgorithm, message.ENCR_NULL, &attributeType, &keyLength, nil)
+	proposal.EncryptionAlgorithm.BuildTransform(message.TypeEncryptionAlgorithm, message.ENCR_NULL, nil, nil, nil)
 	// INTEG
 	proposal.IntegrityAlgorithm.BuildTransform(message.TypeIntegrityAlgorithm, message.AUTH_HMAC_SHA1_96, nil, nil, nil)
 	// ESN


### PR DESCRIPTION
### Summary

This pull request updates the TNGF test case to include the null encryption during the IKEv2 signalling phase.

### Details

- Added ENCR_NULL as proposed encryption algorithm by the UE (according to TS 23.501 and TS 23.502);
- Modified sk_er and sk_ei keys length to 0 (according to RFC 2410);

### Related

- Follow-up to: https://github.com/free5gc/tngf/pull/14