### PR TITLE
fix: pin gtp5g to v0.9.16 in quick-setup.sh

### DIFF
--- a/quick-setup.sh
+++ b/quick-setup.sh
@@ -9,6 +9,7 @@ LINT=false
 DOCKER=false
 
 GTP5G_PATH="$HOME/gtp5g"
+GTP5G_VERSION="v0.9.16"
 
 SUCCESS_COUNT=0
 FAIL_COUNT=0
@@ -189,7 +190,7 @@ install_gtp5g() {
     sudo apt -y update
     sudo apt -y install gcc g++ cmake autoconf libtool pkg-config libmnl-dev libyaml-dev
 
-    git clone https://github.com/free5gc/gtp5g.git $GTP5G_PATH
+    git clone --branch ${GTP5G_VERSION} https://github.com/free5gc/gtp5g.git $GTP5G_PATH
     pushd $GTP5G_PATH
     make
     sudo make install


### PR DESCRIPTION
The install_gtp5g() function cloned the latest master branch of gtp5g, which is now v0.10.0. However, UPF enforces the constraint:
  0.9.5 <= gtp5g < 0.10.0

Pin the clone to tag v0.9.16 (latest compatible release) to prevent a version-mismatch error when running ./run.sh after quick-setup.