### PR TITLE
feat: add nrfCertPem

### DIFF
--- a/config/bsfcfg.yaml
+++ b/config/bsfcfg.yaml
@@ -13,6 +13,7 @@ configuration:
       pem: cert/bsf.pem # BSF TLS Certificate
       key: cert/bsf.key # BSF TLS Private key
   nrfUri: http://127.0.0.10:8000 # a valid URI of NRF
+  nrfCertPem: cert/nrf.pem # NRF Certificate
   mongodb:
     name: free5gc                      # name of the mongodb
     url: mongodb://127.0.0.1:27017     # a valid URL of the mongodb


### PR DESCRIPTION
This PR is for fixing issue [#851](https://github.com/free5gc/free5gc/issues/851)

Configuration update:
  - Added `nrfCertPem` field to specify the NRF certificate file path in `config/bsfcfg.yaml`.