### PR TITLE
Check modern mongosh and fallback to mongo

### DIFF
--- a/force_kill.sh
+++ b/force_kill.sh
@@ -48,14 +48,20 @@ sudo rm -f test/cert/*_*
 sudo rm -f /tmp/config.json # CHF ChargingGatway FTP config
 
 if [ $DROP_ALL_DB -eq 1 ]; then
-    mongo --eval "db.dropDatabase()" "$DB_NAME"
-    mongosh --eval "db.dropDatabase()" "$DB_NAME"
+    if command -v mongosh &> /dev/null; then
+        mongosh --eval "db.dropDatabase()" "$DB_NAME"
+    else
+        mongo --eval "db.dropDatabase()" "$DB_NAME"
+    fi
 else
     MONGO_SCRIPT=""
     for COLLECTION in "${DB_DROP_COLLECTION[@]}"
     do
         MONGO_SCRIPT+="db.$COLLECTION.drop();"
     done
-    mongo "$DB_NAME" --eval "$MONGO_SCRIPT"
-    mongosh "$DB_NAME" --eval "$MONGO_SCRIPT" 
+    if command -v mongosh &> /dev/null; then
+        mongosh "$DB_NAME" --eval "$MONGO_SCRIPT" 
+    else
+        mongo "$DB_NAME" --eval "$MONGO_SCRIPT"
+    fi
 fi

--- a/run.sh
+++ b/run.sh
@@ -136,8 +136,11 @@ for COLLECTION in "${DB_DROP_COLLECTION[@]}"
 do
     MONGO_SCRIPT+="db.$COLLECTION.drop();"
 done
-mongo "$DB_NAME" --eval "$MONGO_SCRIPT"
-mongosh "$DB_NAME" --eval "$MONGO_SCRIPT" 
+if command -v mongosh &> /dev/null; then
+    mongosh "$DB_NAME" --eval "$MONGO_SCRIPT" 
+else
+    mongo "$DB_NAME" --eval "$MONGO_SCRIPT"
+fi
 
 sleep 0.1
 


### PR DESCRIPTION
## Why

Current `run.sh` and `force_kill.sh` try to run two commands (`mongo` and `mongosh`) for the same operation on MongoDB.

`mongo` has been deprecated and `mongosh` is a modern successor of it. Thus in most cases, you have only one of them.

The current implementation works fine, however you would get distracted by an error message complaining about the non-existing binary (either `mongo` or `mongosh`)

## What & How

I updated the scripts to first check if the modern `mongosh` exists, if so, run the `mongosh` command. Otherwise, run the `mongo` command.

## Benifit

There is no change on behaviors and results. It avoids an unnecessary and possibly misleading error message