### PR TITLE
fix: update non-3GPP test using random IKEv2 IDi 

### DIFF
--- a/test/non3gpp_test.go
+++ b/test/non3gpp_test.go
@@ -1000,7 +1000,14 @@ func TestNon3GPPUE(t *testing.T) {
 	var ikePayload ike_message.IKEPayloadContainer
 
 	// Identification
-	ikePayload.BuildIdentificationInitiator(ike_message.ID_KEY_ID, []byte("UE"))
+	idByte := make([]byte, 8)
+	id, err := ike_security.GenerateRandomNumber()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	binary.BigEndian.PutUint64(idByte, id.Uint64())
+	ikePayload.BuildIdentificationInitiator(ike_message.ID_KEY_ID, idByte)
 
 	// Security Association
 	securityAssociation = ikePayload.BuildSecurityAssociation()
@@ -1317,7 +1324,7 @@ func TestNon3GPPUE(t *testing.T) {
 	}
 
 	var idPayload ike_message.IKEPayloadContainer
-	idPayload.BuildIdentificationInitiator(ike_message.ID_KEY_ID, []byte("UE"))
+	idPayload.BuildIdentificationInitiator(ike_message.ID_KEY_ID, idByte)
 	idPayloadData, err := idPayload.Encode()
 	if err != nil {
 		t.Fatalf("Encode IKE payload failed : %+v", err)


### PR DESCRIPTION
### Summary
TS 33.501 Section 7.2.1 specifies that the UE shall set the ID initiator (**IDi**) payload to the ID_KEY_ID type in the first IKE_AUTH message, and that its value shall be an arbitrary random number. Currently, the non-3GPP test case uses the hardcoded string "UE" as the IDi value.

This pull request updates the non-3GPP test case by replacing the hardcoded value with a randomly generated uint64, using the _GenerateRandomNumber()_ function.

### Validation
Tested with Free5GC v4.2.2 (commit eef1d0fe9867c245673d2e2345eeff79c48e04ef). Test Passed.

    