### PR TITLE
config: add commented SMF Event Exposure UPF endpoint example

### DIFF
--- a/config/smfcfg.yaml
+++ b/config/smfcfg.yaml
@@ -66,6 +66,10 @@ configuration:
         type: UPF # the type of the node (AN or UPF)
         nodeID: 127.0.0.8 # the Node ID of this UPF
         addr: 127.0.0.8 # the IP/FQDN of N4 interface on this UPF (PFCP)
+        # Optional Nupf Event Exposure API root for SMF Event Exposure.
+        # The SMF appends /nupf-ee/v1 when calling the selected UPF.
+        # Enable only when this UPF exposes Nupf_EventExposure at this API root.
+        # nupfEeApiRoot: http://upf.example.com:<nupf-ee-port>
         sNssaiUpfInfos: # S-NSSAI information list for this UPF
           - sNssai: # S-NSSAI (Single Network Slice Selection Assistance Information)
               sst: 1 # Slice/Service Type (uinteger, range: 0~255)


### PR DESCRIPTION
## Summary

This Draft PR adds a commented `nupfEeApiRoot` example to the default SMF
configuration.

The field is used by the SMF Event Exposure implementation to locate the
selected UPF's Nupf Event Exposure API root. The example is intentionally
commented and does not enable any active UPF endpoint by default.

## Dependency Status

This Draft PR is stacked on:

- free5gc/openapi#77
- free5gc/smf#225

It should remain Draft until those dependencies are available from canonical
upstream revisions. This PR does not claim final integration readiness.

## Changes

- Add a commented `nupfEeApiRoot` example under
  `configuration.userplaneInformation.upNodes.UPF` in `config/smfcfg.yaml`.
- Keep the example generic:
  - no active endpoint default
  - no testbed IP address
  - no private hostname
  - no callback URI
  - no credential or secret
- Do not update submodule pointers.

## Notes

The SMF appends `/nupf-ee/v1` when calling the selected UPF. The configured
value should not include the `/nupf-ee/v1` service path.

The example should only be enabled by deployments where the selected UPF exposes
Nupf Event Exposure at the configured API root.

Submodule pointer updates are intentionally deferred until the OpenAPI and SMF
dependencies are canonical, or until maintainers explicitly request a stacked
dependency update.

## Validation

Passed locally:

```bash
git diff --check
python3 -c 'import yaml, pathlib; yaml.safe_load(pathlib.Path("config/smfcfg.yaml").read_text()); print("yaml parse ok")'
```

The change is comment-only and does not alter active runtime configuration.

## Related PRs

Depends on free5gc/openapi#77 and free5gc/smf#225.