### PR TITLE
feat(config): add EES configuration to UPF config

### DIFF
--- a/config/upfcfg.yaml
+++ b/config/upfcfg.yaml
@@ -39,3 +39,10 @@ logger:
   enable: true # true or false
   level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
   reportCaller: false # enable the caller report or not, value: true or false
+
+ees:
+  enabled: true # true or false
+  ip: "[IP_ADDRESS]" # IP used to bind the service
+  port: 8088 # Port used to bind the service
+  periodSec: 5 # how often to collect data
+


### PR DESCRIPTION
## Description
This Pull Request adds the Edge Enabler Server (EES) configuration settings (`ip` and `port`) to `upfcfg.yaml`.

This change is in coordination with the go-upf changes in https://github.com/free5gc/go-upf/pull/79.

## Changes
- Add `ees` configuration block to `config / upfcfg.yaml`.